### PR TITLE
Binderise the notebooks repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # notebooks
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/networkx/notebooks/master)
+
 Examples and IPython Notebooks about NetworkX
 
 ## Installation requirements ##

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,5 @@
+#Dependency of pygraphviz
+libgraphviz-dev
+
+#Required for some examples
+graphviz


### PR DESCRIPTION
Add in dependencies required to launch this rep on [MyBinder](https://mybinder.org/).

Note the button link is for the official repo. To test the PR fork on MyBinder, use this link: https://mybinder.org/v2/gh/ouseful-PR/notebooks/binderise

The repo could be further tidied by moving the `requirements.txt` and `apt.txt` files into a `binder/` directory at the top level of the repo.
