### PR TITLE
Switch to pydata sphinx theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ nbval
 git+git://github.com/networkx/networkx@main
 sphinx
 myst-nb
-sphinx-book-theme
+pydata-sphinx-theme==0.5.2
 jupytext

--- a/site/conf.py
+++ b/site/conf.py
@@ -45,22 +45,26 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_book_theme'
+html_theme = 'pydata_sphinx_theme'
 html_title = 'NetworkX Notebooks'
 html_logo = '_static/networkx_logo.svg'
 # html_favicon
 html_theme_options = {
-    "github_url": "https://github.com/networkx/notebooks/",
-    "repository_url": "https://github.com/networkx/notebooks/",
-    "repository_branch": "main",
-    "use_repository_button": True,
-    "use_issues_button": True,
+    "github_url": "https://github.com/networkx/notebooks",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/networkx/notebooks/",
+            "icon": "fab fa-github-square",
+        },
+    ],
     "use_edit_page_button": True,
-    "path_to_docs": "site/",
-    "launch_buttons": {
-        "binderhub_url": "https://mybinder.org",
-#        "jupyterhub_url": 
-    },
+}
+html_context = {
+    "github_user": "networkx",
+    "github_repo": "notebooks",
+    "github_version": "main",
+    "doc_path": "site",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/site/conf.py
+++ b/site/conf.py
@@ -50,12 +50,16 @@ html_title = 'NetworkX Notebooks'
 html_logo = '_static/networkx_logo.svg'
 # html_favicon
 html_theme_options = {
-    "github_url": "https://github.com/networkx/notebooks",
     "icon_links": [
         {
             "name": "GitHub",
             "url": "https://github.com/networkx/notebooks/",
             "icon": "fab fa-github-square",
+        },
+        {
+            "name": "Binder",
+            "url": "https://mybinder.org/v2/gh/networkx/notebooks/main?urlpath=lab/tree/content",
+            "icon": "fas fa-rocket",
         },
     ],
     "use_edit_page_button": True,

--- a/site/index.md
+++ b/site/index.md
@@ -3,7 +3,7 @@ Welcome to NetworkX-notebooks
 
 [![Binder](https://mybinder.org/badge_logo.svg)][launch_binder]
 
-[launch_binder]: https://mybinder.org/v2/gh/networkx/networkx-notebooks/main?urlpath=lab/tree/content
+[launch_binder]: https://mybinder.org/v2/gh/networkx/notebooks/main?urlpath=lab/tree/content
 
 This site provides educational materials officially developed and curated by the
 NetworkX community.


### PR DESCRIPTION
The plan is to link to the notebooks repo directly from the
main docs, so it makes sense that the themes be consistent.

Although the sphinx-book-theme has some nice features and is
pretty similar, it would be nice to have the themes between
the main docs and notebooks be identical