### PR TITLE
Drop Python 3.7 from test workflow.

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 12
       matrix:
         os: [Ubuntu-20.04, macOS-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Drop Python 3.7 from testing matrix for consistency with `networkx/main`